### PR TITLE
Add keybinding to toggle AtlasLootFu

### DIFF
--- a/AtlasLootFu/AtlasLootFu.lua
+++ b/AtlasLootFu/AtlasLootFu.lua
@@ -7,7 +7,7 @@ Description : Adds AtlasLoot to FuBar.
 ]]
 
 BINDING_HEADER_AtlasLootFu = "AtlasLoot"
-BINDING_NAME_AtlasLootFu = "Toggle window"
+BINDING_NAME_AtlasLootFu = "Toggle AtlasLoot Window"
 
 --Invoke libraries
 local tablet = AceLibrary("Tablet-2.0");

--- a/AtlasLootFu/AtlasLootFu.lua
+++ b/AtlasLootFu/AtlasLootFu.lua
@@ -6,6 +6,9 @@ Website     : http://www.atlasloot.net
 Description : Adds AtlasLoot to FuBar.
 ]]
 
+BINDING_HEADER_AtlasLootFu = "AtlasLoot"
+BINDING_NAME_AtlasLootFu = "Toggle window"
+
 --Invoke libraries
 local tablet = AceLibrary("Tablet-2.0");
 

--- a/AtlasLootFu/Bindings.xml
+++ b/AtlasLootFu/Bindings.xml
@@ -1,4 +1,4 @@
 <Bindings>
-	<Binding name="Toggle window" header="ATLASLOOT">
+	<Binding name="AtlasLootFu" header="AtlasLootFu">
 		AtlasLootFu:OnClick("LeftButton")</Binding>
 </Bindings>

--- a/AtlasLootFu/Bindings.xml
+++ b/AtlasLootFu/Bindings.xml
@@ -1,0 +1,4 @@
+<Bindings>
+	<Binding name="Toggle window" header="ATLASLOOT">
+		AtlasLootFu:OnClick("LeftButton")</Binding>
+</Bindings>


### PR DESCRIPTION
Add a Bindings.xml and define binding constants in AtlasLootFu.lua to enable a user-configurable keybinding for toggling the AtlasLootFu window. Bindings.xml registers a "Toggle window" binding that calls AtlasLootFu:OnClick("LeftButton"), and the Lua file exposes BINDING_HEADER_AtlasLoot and BINDING_NAME_AtlasLootFu.